### PR TITLE
Add System Variable for day, month and year / Fix for "Calculate" function to recognize minus-sign

### DIFF
--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -1808,7 +1808,7 @@ int Calculate(const char *input, float* result)
 
   //*sp=0; // bug, it stops calculating after 50 times
   sp = globalstack - 1;
-  oc=0;
+  oc=c=0;
   while (strpos < strend)
   {
     // read one token from the input stream

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -1474,17 +1474,28 @@ String getTimeString(char delimiter)
   return reply;
 }
 
-String getTimeStringShort(char delimiter)
+String getHourString()
 {
   String reply;
   if (hour() < 10)
     reply += F("0");
   reply += String(hour());
-  if (delimiter != '\0')
-    reply += delimiter;
+  return reply;
+}
+String getMinuteString()
+{
+  String reply;
   if (minute() < 10)
     reply += F("0");
   reply += minute();
+  return reply;
+}
+String getSecondString()
+{
+  String reply;
+  if (second() < 10)
+    reply += F("0");
+  reply += second();
   return reply;
 }
 
@@ -1635,7 +1646,9 @@ String parseTemplate(String &tmpString, byte lineSize)
 
   newString.replace(F("%systime%"), getTimeString(':'));
 
-  newString.replace(F("%systimes%"), getTimeStringShort(':'));
+  newString.replace(F("%syshour%"), getHourString());
+  newString.replace(F("%sysmin%"), getMinuteString());
+  newString.replace(F("%syssec%"), getSecondString());
   newString.replace(F("%sysday%"), getDayString());
   newString.replace(F("%sysmonth%"), getMonthString());
   newString.replace(F("%sysyear%"), getYearString());


### PR DESCRIPTION
It was not possible to display time and date in a reasonable format on LCD displays.
I have added a few variables so that time and date can be displayed as desired.

Variables:
%syshour%
%sysmin%
%syssec%
%sysday%
%sysmonth%
%sysyear% // 4 digits - 2017
%sysyears% // 2 digits - 17

The formula for changing a sensor value had a problem with negative numbers because the function "Calculate" recognized the "minus sign" as operand and not as a sign for negative numbers.

The function "pop" had a problem with empty stack which leads to undefined return values.